### PR TITLE
Allow modal to close by clicking outside

### DIFF
--- a/components/GameHistory.tsx
+++ b/components/GameHistory.tsx
@@ -30,8 +30,14 @@ export default function GameHistory({
   }
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white dark:bg-white text-black dark:text-black p-6 rounded-lg shadow-xl max-w-4xl w-full max-h-[90vh] overflow-y-auto">
+    <div
+      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white dark:bg-white text-black dark:text-black p-6 rounded-lg shadow-xl max-w-4xl w-full max-h-[90vh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
         <h2 className="text-2xl font-bold mb-4">{t('gameHistory')}</h2>
         {history.length === 0 ? (
           <p>{t('noGameHistory')}</p>


### PR DESCRIPTION
Update `GameHistory.tsx` to allow closing the modal by clicking outside.

* Add `onClick` event listener to the modal's background overlay to trigger the `onClose` function.
* Prevent the modal from closing when clicking inside the modal by stopping the event propagation.

