### PR TITLE
Fix misaligned input fields

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -86,4 +86,5 @@
 
 .input {
   @apply p-2 rounded border-2 border-input focus:border-ring focus:outline-none text-lg bg-background;
+  @apply w-full max-w-xs;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -262,7 +262,7 @@ function GameWithSearchParams() {
                     type="text"
                     value={shareLink}
                     readOnly
-                    className="input flex-grow"
+                    className="input flex-grow w-full"
                   />
                   <button onClick={copyShareLink} className="btn btn-secondary">
                     {t('copy')}


### PR DESCRIPTION
Align input fields generated by the "Generate Share Link" button and the "Edit Player Name" functionality within their intended layout.

* **app/globals.css**
  - Update the `.input` class to include `w-full` and `max-w-xs` for consistent width and alignment.

* **app/page.tsx**
  - Modify the input field for the share link to include `w-full` for proper alignment.

