### PR TITLE
Fix input width to adjust to parent container

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -86,5 +86,6 @@
 
 .input {
   @apply p-2 rounded border-2 border-input focus:border-ring focus:outline-none text-lg bg-background;
-  @apply w-full max-w-xs;
+  @apply w-full;
+  @apply max-w-full;
 }


### PR DESCRIPTION
Fixes #22

Update the `.input` class in `app/globals.css` to adjust input width on larger screens.

* Remove the `max-w-xs` class from the `.input` class.
* Set the `max-width` property to `100%` in the `.input` class.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/chrsmendes/game-score/pull/23?shareId=92d426e6-bba7-4970-952d-b250ae42db04).