### PR TITLE
Add info buttons for input fields

### DIFF
--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -54,4 +54,7 @@ export default {
   dark: 'Dark',
   light: 'Light',
   deleteHistory: 'Delete history item',
+  gameNameTooltip: 'Examples: "Truco" or "Uno"',
+  targetScoreTooltip: 'Examples: "In Truco, the target score is 12"',
+  initialPointsTooltip: 'Examples: "All players start with 50 points, and the goal is to reach 0"',
 }

--- a/app/locales/es.ts
+++ b/app/locales/es.ts
@@ -54,4 +54,7 @@ export default {
   dark: 'Oscuro',
   light: 'Claro',
   deleteHistory: 'Eliminar elemento del historial',
+  gameNameTooltip: 'Ejemplos: "Truco" o "Uno"',
+  targetScoreTooltip: 'Ejemplos: "En Truco, la puntuación objetivo es 12"',
+  initialPointsTooltip: 'Ejemplos: "Todos los jugadores comienzan con 50 puntos, y el objetivo es llegar a 0"',
 }

--- a/app/locales/pt.ts
+++ b/app/locales/pt.ts
@@ -54,4 +54,7 @@ export default {
   dark: 'Escuro',
   light: 'Claro',
   deleteHistory: 'Excluir item do histórico',
+  gameNameTooltip: 'Exemplos: "Truco" ou "Uno"',
+  targetScoreTooltip: 'Exemplos: "No Truco, a pontuação objetivo é 12"',
+  initialPointsTooltip: 'Exemplos: "Todos os jogadores começam com 50 pontos, e o objetivo é chegar a 0"',
 }

--- a/components/GameSetup.tsx
+++ b/components/GameSetup.tsx
@@ -1,6 +1,13 @@
 import { useState, useEffect } from 'react'
 import { GameState } from '../app/types'
 import { useLanguage } from './LanguageContext'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { Info } from 'lucide-react'
 
 interface GameSetupProps {
   setGameState: (state: Partial<GameState>) => void
@@ -47,6 +54,14 @@ export default function GameSetup({
         <div>
           <label htmlFor="gameName" className="block mb-2 text-xl">
             {t('gameName')}:
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger>
+                  <Info className="ml-2 inline-block text-gray-500" />
+                </TooltipTrigger>
+                <TooltipContent>{t('gameNameTooltip')}</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           </label>
           <input
             type="text"
@@ -61,6 +76,14 @@ export default function GameSetup({
       <div>
         <label htmlFor="targetScore" className="block mb-2 text-xl">
           {t('targetScore')}:
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger>
+                <Info className="ml-2 inline-block text-gray-500" />
+              </TooltipTrigger>
+              <TooltipContent>{t('targetScoreTooltip')}</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         </label>
         <input
           type="number"
@@ -76,6 +99,14 @@ export default function GameSetup({
         <div>
           <label htmlFor="initialPoints" className="block mb-2 text-xl">
             {t('initialPoints')}:
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger>
+                  <Info className="ml-2 inline-block text-gray-500" />
+                </TooltipTrigger>
+                <TooltipContent>{t('initialPointsTooltip')}</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           </label>
           <input
             type="number"

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import * as React from "react"
+import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+
+import { cn } from "@/lib/utils"
+
+const TooltipProvider = TooltipPrimitive.Provider
+
+const Tooltip = TooltipPrimitive.Root
+
+const TooltipTrigger = TooltipPrimitive.Trigger
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
+))
+TooltipContent.displayName = TooltipPrimitive.Content.displayName
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
+    "@radix-ui/react-tooltip": "^1.1.6",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "fork-ts-checker-webpack-plugin": "^9.0.2",


### PR DESCRIPTION
Fixes #11

Add informational tooltips for input fields in GameSetup component and update locale files.

* **GameSetup Component:**
  - Import Tooltip components from shadcn and Info icon from lucide-react.
  - Add TooltipProvider, Tooltip, TooltipTrigger, and TooltipContent for Game Name, Target Score, and Starting Points input fields.
  - Provide examples and explanations in tooltips for each input field.

* **Locale Files:**
  - Update `app/locales/en.ts` with tooltip-related translations for Game Name, Target Score, and Starting Points.
  - Update `app/locales/es.ts` with tooltip-related translations for Game Name, Target Score, and Starting Points.
  - Update `app/locales/pt.ts` with tooltip-related translations for Game Name, Target Score, and Starting Points.

* **Dependencies:**
  - Add `@radix-ui/react-tooltip` dependency in `package.json`.

* **New File:**
  - Add `components/ui/tooltip.tsx` to define Tooltip components using shadcn.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/chrsmendes/game-score/pull/24?shareId=6ca06170-775e-4203-bcd4-9e1eb58f4091).