### PR TITLE
Add success notification for share link copy

### DIFF
--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -56,5 +56,7 @@ export default {
   deleteHistory: 'Delete history item',
   gameNameTooltip: 'Examples: "Truco" or "Uno"',
   targetScoreTooltip: 'Examples: "In Truco, the target score is 12"',
-  initialPointsTooltip: 'Examples: "All players start with 50 points, and the goal is to reach 0"',
+  initialPointsTooltip:
+    'Examples: "All players start with 50 points, and the goal is to reach 0"',
+  closeInput: 'Close',
 }

--- a/app/locales/es.ts
+++ b/app/locales/es.ts
@@ -56,5 +56,7 @@ export default {
   deleteHistory: 'Eliminar elemento del historial',
   gameNameTooltip: 'Ejemplos: "Truco" o "Uno"',
   targetScoreTooltip: 'Ejemplos: "En Truco, la puntuación objetivo es 12"',
-  initialPointsTooltip: 'Ejemplos: "Todos los jugadores comienzan con 50 puntos, y el objetivo es llegar a 0"',
+  initialPointsTooltip:
+    'Ejemplos: "Todos los jugadores comienzan con 50 puntos, y el objetivo es llegar a 0"',
+  closeInput: 'Cerrar',
 }

--- a/app/locales/pt.ts
+++ b/app/locales/pt.ts
@@ -56,5 +56,7 @@ export default {
   deleteHistory: 'Excluir item do histórico',
   gameNameTooltip: 'Exemplos: "Truco" ou "Uno"',
   targetScoreTooltip: 'Exemplos: "No Truco, a pontuação objetivo é 12"',
-  initialPointsTooltip: 'Exemplos: "Todos os jogadores começam com 50 pontos, e o objetivo é chegar a 0"',
+  initialPointsTooltip:
+    'Exemplos: "Todos os jogadores começam com 50 pontos, e o objetivo é chegar a 0"',
+  closeInput: 'Fechar',
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -49,6 +49,7 @@ function GameWithSearchParams() {
   const [shareLink, setShareLink] = useState('')
   const [showHistory, setShowHistory] = useState(false)
   const [gameHistory, setGameHistory] = useState<GameRound[]>([])
+  const [copySuccess, setCopySuccess] = useState(false)
 
   useEffect(() => {
     localStorage.setItem('gameState', JSON.stringify(gameState))
@@ -151,7 +152,11 @@ function GameWithSearchParams() {
   const copyShareLink = () => {
     navigator.clipboard
       .writeText(shareLink)
-      .then(() => alert(t('linkCopied')))
+      .then(() => {
+        setCopySuccess(true)
+        setTimeout(() => setCopySuccess(false), 2000)
+        setShareLink('')
+      })
       .catch((err) => console.error('Failed to copy link:', err))
   }
 
@@ -267,7 +272,16 @@ function GameWithSearchParams() {
                   <button onClick={copyShareLink} className="btn btn-secondary">
                     {t('copy')}
                   </button>
+                  <button
+                    onClick={() => setShareLink('')}
+                    className="btn btn-danger"
+                  >
+                    {t('closeInput')}
+                  </button>
                 </div>
+              )}
+              {copySuccess && (
+                <div className="mt-2 text-green-500">{t('linkCopied')}</div>
               )}
             </div>
           </>

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -1,9 +1,9 @@
-"use client"
+'use client'
 
-import * as React from "react"
-import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+import * as React from 'react'
+import * as TooltipPrimitive from '@radix-ui/react-tooltip'
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils'
 
 const TooltipProvider = TooltipPrimitive.Provider
 
@@ -20,7 +20,7 @@ const TooltipContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        'z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         className
       )}
       {...props}


### PR DESCRIPTION
Fixes #12

Add a success notification for the share link copy action and close the input and button after copying.

* Add a state variable `copySuccess` to manage the notification display in `app/page.tsx`.
* Update the `copyShareLink` function to set `copySuccess` to true upon successful copy and clear the `shareLink` state.
* Add a conditional rendering of the notification message "Link copied successfully!" in `app/page.tsx`.
* Add a close button next to the input field to clear the `shareLink` state.
* Add the new translation key `closeInput` with appropriate values in `app/locales/en.ts`, `app/locales/es.ts`, and `app/locales/pt.ts`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/chrsmendes/game-score/pull/25?shareId=e390acd4-6bb9-4765-9f2f-cecea93c1f28).