### PR TITLE
Add URL for full changelog in Changelog component

### DIFF
--- a/components/Changelog/Changelog.tsx
+++ b/components/Changelog/Changelog.tsx
@@ -3,9 +3,14 @@ import './style.css'
 interface ChangelogProps {
   version: string
   changelog: string
+  urlReleaseInfo: string
 }
 
-export default function Changelog({ version, changelog }: ChangelogProps) {
+export default function Changelog({
+  version,
+  changelog,
+  urlReleaseInfo,
+}: ChangelogProps) {
   return (
     <div className="mt-2 p-2 shadow-lg rounded-lg">
       <h3 className="font-bold text-center">{version} Changelog:</h3>
@@ -13,6 +18,11 @@ export default function Changelog({ version, changelog }: ChangelogProps) {
         className="markdown-content p-6"
         dangerouslySetInnerHTML={{ __html: changelog }}
       />
+      <div className="markdown-content">
+        <a href={urlReleaseInfo} className="block text-center mt-2">
+          View full changelog
+        </a>
+      </div>
     </div>
   )
 }

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -10,13 +10,13 @@ export default function Footer() {
   const [version, setVersion] = useState('')
   const [changelog, setChangelog] = useState('')
   const [error, setError] = useState(false)
+  const urlReleaseInfo =
+    'https://api.github.com/repos/chrsmendes/game-score/releases/latest'
 
   useEffect(() => {
     const fetchReleaseInfo = async () => {
       try {
-        const response = await fetch(
-          'https://api.github.com/repos/chrsmendes/game-score/releases/latest'
-        )
+        const response = await fetch(urlReleaseInfo)
         if (!response.ok) {
           throw new Error('Network response was not ok')
         }
@@ -72,7 +72,11 @@ export default function Footer() {
             </p>
           </div>
         ) : (
-          <Changelog version={version} changelog={changelog} />
+          <Changelog
+            version={version}
+            changelog={changelog}
+            urlReleaseInfo={urlReleaseInfo}
+          />
         ))}
     </footer>
   )


### PR DESCRIPTION
Fixes #13

This pull request includes changes to the `Changelog` and `Footer` components to enhance the display of release information by adding a link to view the full changelog.

Enhancements to `Changelog` component:

* Updated `ChangelogProps` interface to include `urlReleaseInfo` property and modified the `Changelog` function to accept this new property. Added a link to the full changelog within the component.

Enhancements to `Footer` component:

* Introduced a `urlReleaseInfo` constant to store the URL for fetching the latest release information. Updated the fetch call to use this constant.
* Modified the `Changelog` component usage to pass the `urlReleaseInfo` property.