### PR TITLE
Add GitHub repository link

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useLanguage } from './LanguageContext'
-import { Info } from 'lucide-react'
+import { Info, Github } from 'lucide-react'
 import Changelog from './Changelog/Changelog'
 import { marked } from 'marked'
 
@@ -63,6 +63,15 @@ export default function Footer() {
         >
           <Info size={16} />
         </button>
+        <a
+          href="https://github.com/chrsmendes/game-score"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-500 hover:text-blue-600"
+          aria-label="GitHub Repository"
+        >
+          <Github size={16} />
+        </a>
       </div>
       {showChangelog &&
         (error ? (


### PR DESCRIPTION
Fixes #14

Add a GitHub icon with a link to the repository in the footer.

* Import `Github` icon from `lucide-react`.
* Add a `Github` icon with a link to the repository in the footer.
* Position the `Github` icon next to the game version and changelog button.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/chrsmendes/game-score/pull/28?shareId=ee31bfcf-b17c-4266-b1c0-2e565fa4a12b).