### PR TITLE
Fix too many redirects error

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -13,20 +13,7 @@ const nextConfig = {
     defaultLocale: 'en',
   },
   async rewrites() {
-    if (process.env.NODE_ENV === 'development') {
-      return [
-        {
-          source: '/:path*',
-          destination: `http://localhost:3000/:path*`,
-        },
-      ]
-    }
-    return [
-      {
-        source: '/:path*',
-        destination: `https://game-score.chmendes.com.br/:path*`,
-      },
-    ]
+    return []
   },
   async headers() {
     return [

--- a/next.config.js
+++ b/next.config.js
@@ -3,17 +3,18 @@ const withPWA = require('next-pwa')({
   register: true,
   skipWaiting: true,
   buildExcludes: [/middleware-manifest\.json$/],
-  disable: process.env.NODE_ENV === 'development', // Add this line
-})
+  disable: process.env.NODE_ENV === 'development', // Desativa PWA em desenvolvimento
+});
 
 const nextConfig = {
   reactStrictMode: true,
   i18n: {
     locales: ['en', 'pt', 'es'],
     defaultLocale: 'en',
+    localeDetection: false, // Evita redirecionamentos automáticos baseados no idioma do navegador
   },
   async rewrites() {
-    return []
+    return [];
   },
   async headers() {
     return [
@@ -26,20 +27,20 @@ const nextConfig = {
           },
         ],
       },
-    ]
+    ];
   },
   webpack: (config, { dev, isServer }) => {
     if (dev && !isServer) {
-      const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin')
-      config.plugins.push(new ForkTsCheckerWebpackPlugin())
+      const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+      config.plugins.push(new ForkTsCheckerWebpackPlugin());
     }
     if (!dev && !isServer) {
       console.warn(
-        '⚠ GenerateSW has been called multiple times, perhaps due to running webpack in --watch mode. The precache manifest generated after the first call may be inaccurate! Please see https://github.com/GoogleChrome/workbox/issues/1790 for more information.'
-      )
+        '⚠ GenerateSW has been chamado várias vezes. Verifique o precache manifest para garantir que não há duplicações!'
+      );
     }
-    return config
+    return config;
   },
-}
+};
 
-module.exports = withPWA(nextConfig)
+module.exports = withPWA(nextConfig);


### PR DESCRIPTION
Fixes #30

Remove the rewrite rule in `next.config.js` that redirects all paths to `https://game-score.chmendes.com.br/:path*`.

* Ensure the `rewrites` function returns an empty array.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/chrsmendes/game-score/pull/31?shareId=1b5988ab-8e0c-4234-b98d-811020383357).