### PR TITLE
Add manual game finish flow

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -130,7 +130,8 @@
 
 @layer components {
   .btn {
-    @apply inline-flex items-center justify-center gap-2 rounded-full border px-5 py-3 text-sm font-semibold tracking-[0.02em] transition-all duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 disabled:cursor-not-allowed disabled:opacity-60;
+    @apply inline-flex min-w-0 items-center justify-center gap-2 rounded-full border px-5 py-3 text-center text-sm font-semibold tracking-[0.02em] transition-all duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 disabled:cursor-not-allowed disabled:opacity-60;
+    overflow-wrap: anywhere;
     box-shadow: 0 18px 40px -28px hsl(var(--foreground) / 0.45);
   }
 
@@ -151,19 +152,20 @@
   }
 
   .input {
-    @apply w-full rounded-[1.25rem] border border-input bg-background/85 px-4 py-3 text-base shadow-sm outline-none transition-all duration-200 placeholder:text-muted-foreground/75 focus:border-ring focus:ring-4 focus:ring-ring/10;
+    @apply w-full min-w-0 rounded-[1.25rem] border border-input bg-background/85 px-4 py-3 text-base shadow-sm outline-none transition-all duration-200 placeholder:text-muted-foreground/75 focus:border-ring focus:ring-4 focus:ring-ring/10;
   }
 
   .surface-panel {
-    @apply rounded-[2rem] border border-border/70 bg-card/80 text-card-foreground shadow-[0_24px_80px_-40px_hsl(var(--foreground)/0.45)] backdrop-blur-xl;
+    @apply min-w-0 rounded-[2rem] border border-border/70 bg-card/80 text-card-foreground shadow-[0_24px_80px_-40px_hsl(var(--foreground)/0.45)] backdrop-blur-xl;
   }
 
   .section-label {
-    @apply inline-flex items-center gap-2 rounded-full border border-border/70 bg-background/70 px-3 py-1 text-[0.7rem] font-semibold uppercase tracking-[0.22em] text-muted-foreground;
+    @apply inline-flex max-w-full min-w-0 items-center gap-2 rounded-full border border-border/70 bg-background/70 px-3 py-1 text-[0.7rem] font-semibold uppercase tracking-[0.22em] text-muted-foreground;
+    overflow-wrap: anywhere;
   }
 
   .metric-card {
-    @apply rounded-[1.75rem] border border-border/70 bg-background/70 p-4 shadow-sm backdrop-blur;
+    @apply min-w-0 rounded-[1.75rem] border border-border/70 bg-background/70 p-4 shadow-sm backdrop-blur;
   }
 
   .ghost-link {

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -6,6 +6,7 @@ const en = {
   startGame: 'Start Game',
   updateGame: 'Update Game',
   restartGame: 'Restart Game',
+  finishGame: 'Finish Game',
   changeTarget: 'Change Game Target',
   newGame: 'New Game',
   close: 'Close',

--- a/app/locales/es.ts
+++ b/app/locales/es.ts
@@ -6,6 +6,7 @@ const es = {
   startGame: 'Iniciar Juego',
   updateGame: 'Actualizar Juego',
   restartGame: 'Reiniciar Juego',
+  finishGame: 'Finalizar Juego',
   changeTarget: 'Cambiar Meta del Juego',
   changeTargetScore: 'Cambiar Puntuación Objetivo',
   updateTargetScore: 'Actualizar Puntuación Objetivo',

--- a/app/locales/pt.ts
+++ b/app/locales/pt.ts
@@ -6,6 +6,7 @@ const pt = {
   startGame: 'Iniciar Jogo',
   updateGame: 'Atualizar Jogo',
   restartGame: 'Reiniciar Jogo',
+  finishGame: 'Terminar Jogo',
   changeTarget: 'Trocar Meta do Jogo',
   newGame: 'Novo Jogo',
   close: 'Fechar',

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useEffect, useState } from 'react'
 import { useSearchParams } from 'next/navigation'
 import {
+  Flag,
   History,
   Link2,
   RotateCcw,
@@ -124,6 +125,11 @@ function GameWithSearchParams() {
     setShareLink('')
   }
 
+  const finishGame = () => {
+    saveGameRound(gameState)
+    resetGame()
+  }
+
   const changeTarget = () => {
     setShowTargetScoreUpdate(true)
   }
@@ -240,56 +246,38 @@ function GameWithSearchParams() {
         {!gameState.gameName || showSetup ? (
           <section className="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_360px]">
             <div className="surface-panel p-5 sm:p-6 lg:p-8">
-              <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_250px]">
-                <div className="space-y-6">
-                  <div className="space-y-4">
-                    <span className="section-label">{t('startGame')}</span>
-                    <div className="space-y-2">
-                      <h2 className="text-3xl font-semibold tracking-[-0.05em] sm:text-4xl">
-                        Game Score
-                      </h2>
-                      <p className="max-w-2xl text-sm leading-6 text-muted-foreground sm:text-base">
-                        {t('gameName')} · {t('targetScore')} ·{' '}
-                        {t('initialPoints')}
-                      </p>
-                    </div>
+              <div className="max-w-3xl space-y-6">
+                <div className="space-y-4">
+                  <span className="section-label">{t('startGame')}</span>
+                  <div className="space-y-2">
+                    <h2 className="text-3xl font-semibold tracking-[-0.05em] sm:text-4xl">
+                      Game Score
+                    </h2>
+                    <p className="max-w-2xl text-sm leading-6 text-muted-foreground sm:text-base">
+                      {t('gameName')} · {t('targetScore')} ·{' '}
+                      {t('initialPoints')}
+                    </p>
                   </div>
-                  <GameSetup
-                    setGameState={(newState) => {
-                      setGameState((prev) => ({
-                        ...prev,
-                        ...newState,
-                        winner: null,
-                      }))
-                      setShowSetup(false)
-                    }}
-                    initialState={gameState}
-                  />
-                  <button
-                    type="button"
-                    onClick={toggleHistory}
-                    className="btn btn-secondary w-full"
-                  >
-                    <History className="h-4 w-4" />
-                    {t('viewGameHistory')}
-                  </button>
                 </div>
-
-                <div className="grid content-start gap-4">
-                  {gameSummary.map((item) => (
-                    <div key={item.label} className="metric-card space-y-3">
-                      <div className="flex items-center justify-between text-muted-foreground">
-                        <span className="text-xs font-semibold uppercase tracking-[0.2em]">
-                          {item.label}
-                        </span>
-                        <item.icon className="h-4 w-4" />
-                      </div>
-                      <p className="text-lg font-semibold leading-tight text-foreground">
-                        {item.value}
-                      </p>
-                    </div>
-                  ))}
-                </div>
+                <GameSetup
+                  setGameState={(newState) => {
+                    setGameState((prev) => ({
+                      ...prev,
+                      ...newState,
+                      winner: null,
+                    }))
+                    setShowSetup(false)
+                  }}
+                  initialState={gameState}
+                />
+                <button
+                  type="button"
+                  onClick={toggleHistory}
+                  className="btn btn-secondary w-full"
+                >
+                  <History className="h-4 w-4" />
+                  {t('viewGameHistory')}
+                </button>
               </div>
             </div>
 
@@ -514,6 +502,14 @@ function GameWithSearchParams() {
                     >
                       <Link2 className="h-4 w-4" />
                       {t('generateShareLink')}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={finishGame}
+                      className="btn btn-secondary w-full"
+                    >
+                      <Flag className="h-4 w-4" />
+                      {t('finishGame')}
                     </button>
                     <button
                       type="button"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -282,7 +282,7 @@ function GameWithSearchParams() {
             </div>
 
             <aside className="surface-panel relative overflow-hidden p-5 sm:p-6">
-              <div className="absolute inset-x-0 top-0 h-28 bg-[radial-gradient(circle_at_top,_hsl(var(--accent)/0.28),_transparent_70%)]" />
+              <div className="pointer-events-none absolute inset-0 rounded-[2rem] bg-[radial-gradient(circle_at_85%_0%,_hsl(var(--accent)/0.18),_transparent_58%)]" />
               <div className="relative space-y-5">
                 <div className="space-y-3">
                   <span className="section-label">
@@ -463,7 +463,7 @@ function GameWithSearchParams() {
               </div>
 
               <div className="surface-panel relative overflow-hidden p-5 sm:p-6">
-                <div className="absolute inset-x-0 top-0 h-24 bg-[radial-gradient(circle_at_top,_hsl(var(--primary)/0.2),_transparent_70%)]" />
+                <div className="pointer-events-none absolute inset-0 rounded-[2rem] bg-[radial-gradient(circle_at_85%_0%,_hsl(var(--primary)/0.16),_transparent_58%)]" />
                 <div className="relative space-y-5">
                   <div className="space-y-3">
                     <span className="section-label">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -206,20 +206,20 @@ function GameWithSearchParams() {
   const latestRounds = gameHistory.slice(0, 3)
 
   return (
-    <main className="relative min-h-screen overflow-visible px-4 py-5 sm:px-6 lg:px-8">
-      <div className="mx-auto flex max-w-6xl flex-col gap-6">
+    <main className="relative min-h-screen overflow-x-hidden px-4 py-5 sm:px-6 lg:px-8">
+      <div className="mx-auto flex w-full max-w-6xl min-w-0 flex-col gap-6">
         <header className="surface-panel relative z-30 overflow-visible px-5 py-6 sm:px-6">
           <div className="pointer-events-none absolute inset-0 rounded-[2rem] bg-[radial-gradient(circle_at_85%_50%,_hsl(var(--primary)/0.24),_transparent_58%)]" />
           <div className="absolute inset-x-6 bottom-0 h-px bg-gradient-to-r from-transparent via-border to-transparent" />
-          <div className="relative flex flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
-            <div className="flex items-start gap-4">
+          <div className="relative flex min-w-0 flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
+            <div className="flex min-w-0 items-start gap-4">
               <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-[1.4rem] bg-primary text-primary-foreground shadow-lg shadow-primary/20">
                 <Trophy className="h-6 w-6" />
               </div>
-              <div className="space-y-3">
+              <div className="min-w-0 space-y-3">
                 <span className="section-label">Game Score</span>
                 <div className="space-y-3">
-                  <h1 className="text-4xl font-semibold tracking-[-0.06em] sm:text-5xl">
+                  <h1 className="break-words text-4xl font-semibold tracking-[-0.06em] sm:text-5xl">
                     Game Score
                   </h1>
                   <div className="flex flex-wrap gap-2 text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
@@ -244,7 +244,7 @@ function GameWithSearchParams() {
         </header>
 
         {!gameState.gameName || showSetup ? (
-          <section className="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_360px]">
+          <section className="grid min-w-0 gap-6 xl:grid-cols-[minmax(0,1.15fr)_360px]">
             <div className="surface-panel p-5 sm:p-6 lg:p-8">
               <div className="max-w-3xl space-y-6">
                 <div className="space-y-4">
@@ -342,7 +342,7 @@ function GameWithSearchParams() {
             </aside>
           </section>
         ) : showTargetScoreUpdate ? (
-          <section className="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_360px]">
+          <section className="grid min-w-0 gap-6 xl:grid-cols-[minmax(0,1.15fr)_360px]">
             <div className="surface-panel p-5 sm:p-6 lg:p-8">
               <div className="space-y-6">
                 <div className="space-y-4">
@@ -376,7 +376,7 @@ function GameWithSearchParams() {
               </div>
             </div>
 
-            <aside className="flex flex-col gap-6">
+            <aside className="flex min-w-0 flex-col gap-6">
               <div className="surface-panel p-5 sm:p-6">
                 <ScoreBoard players={gameState.players} />
               </div>
@@ -403,44 +403,44 @@ function GameWithSearchParams() {
             </aside>
           </section>
         ) : (
-          <section className="grid gap-6 xl:grid-cols-[minmax(0,1.3fr)_390px]">
+          <section className="grid min-w-0 gap-6 xl:grid-cols-[minmax(0,1.3fr)_390px]">
             <div className="surface-panel p-5 sm:p-6 lg:p-8">
-              <div className="space-y-8">
-                <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(240px,290px)]">
-                  <div className="space-y-4">
+              <div className="min-w-0 space-y-8">
+                <div className="grid min-w-0 gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(240px,290px)]">
+                  <div className="min-w-0 space-y-4">
                     <span className="section-label">{t('scoreboard')}</span>
                     <div className="space-y-3">
-                      <h2 className="text-3xl font-semibold tracking-[-0.05em] sm:text-4xl">
+                      <h2 className="break-words text-3xl font-semibold tracking-[-0.05em] sm:text-4xl">
                         {gameState.gameName}
                       </h2>
                       <div className="flex flex-wrap gap-2 text-sm text-muted-foreground">
-                        <span className="rounded-full border border-border/70 bg-background/60 px-3 py-1.5">
+                        <span className="max-w-full break-words rounded-[1.2rem] border border-border/70 bg-background/60 px-3 py-1.5">
                           {t('targetScore')}:{' '}
                           {gameState.targetScore > 0
                             ? formatScore(gameState.targetScore)
                             : t('noTargetScore')}
                         </span>
-                        <span className="rounded-full border border-border/70 bg-background/60 px-3 py-1.5">
+                        <span className="max-w-full break-words rounded-full border border-border/70 bg-background/60 px-3 py-1.5">
                           {t('initialPoints')}:{' '}
                           {formatScore(gameState.initialPoints)}
                         </span>
-                        <span className="rounded-full border border-border/70 bg-background/60 px-3 py-1.5">
+                        <span className="max-w-full break-words rounded-full border border-border/70 bg-background/60 px-3 py-1.5">
                           {t('players')}: {gameState.players.length}
                         </span>
                       </div>
                     </div>
                   </div>
 
-                  <div className="grid gap-3 sm:grid-cols-3 lg:grid-cols-1">
+                  <div className="grid min-w-0 gap-3 sm:grid-cols-3 lg:grid-cols-1">
                     {gameSummary.map((item) => (
                       <div key={item.label} className="metric-card space-y-3">
-                        <div className="flex items-center justify-between text-muted-foreground">
-                          <span className="text-xs font-semibold uppercase tracking-[0.2em]">
+                        <div className="flex min-w-0 items-center justify-between gap-3 text-muted-foreground">
+                          <span className="min-w-0 break-words text-xs font-semibold uppercase tracking-[0.2em]">
                             {item.label}
                           </span>
-                          <item.icon className="h-4 w-4" />
+                          <item.icon className="h-4 w-4 shrink-0" />
                         </div>
-                        <p className="text-lg font-semibold leading-tight">
+                        <p className="break-words text-lg font-semibold leading-tight">
                           {item.value}
                         </p>
                       </div>
@@ -457,7 +457,7 @@ function GameWithSearchParams() {
               </div>
             </div>
 
-            <aside className="flex flex-col gap-6">
+            <aside className="flex min-w-0 flex-col gap-6">
               <div className="surface-panel p-5 sm:p-6">
                 <ScoreBoard players={gameState.players} />
               </div>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -51,19 +51,19 @@ export default function Footer() {
   }, [])
 
   return (
-    <footer className="pb-6 text-sm">
+    <footer className="min-w-0 pb-6 text-sm">
       <div className="surface-panel px-5 py-4">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex items-center gap-3">
+        <div className="flex min-w-0 flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex min-w-0 items-center gap-3">
             <div className="flex h-10 w-10 items-center justify-center rounded-[1rem] bg-primary/10 text-primary">
               <Sparkles className="h-4 w-4" />
             </div>
-            <p className="text-sm font-medium text-muted-foreground">
+            <p className="min-w-0 break-words text-sm font-medium text-muted-foreground">
               <span className="font-semibold text-foreground">Game Score</span>{' '}
               {version} ({t('beta')})
             </p>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex min-w-0 flex-wrap items-center gap-2">
             <button
               type="button"
               onClick={() => setShowChangelog(!showChangelog)}

--- a/components/LanguageSelector.tsx
+++ b/components/LanguageSelector.tsx
@@ -1,13 +1,40 @@
-import { useState, useRef, useEffect } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useLanguage } from './LanguageContext'
 import { Check, ChevronDown, Globe2 } from 'lucide-react'
 
 export default function LanguageSelector() {
   const { locale, setLocale } = useLanguage()
   const [isOpen, setIsOpen] = useState(false)
+  const [dropdownAlign, setDropdownAlign] = useState<'left' | 'right'>('right')
   const dropdownRef = useRef<HTMLDivElement>(null)
 
-  const toggleDropdown = () => setIsOpen(!isOpen)
+  const updateDropdownAlignment = useCallback(() => {
+    if (!dropdownRef.current) {
+      return
+    }
+
+    const triggerRect = dropdownRef.current.getBoundingClientRect()
+    const dropdownWidth = 208
+    const viewportPadding = 16
+    const spaceRight = window.innerWidth - triggerRect.left - viewportPadding
+    const spaceLeft = triggerRect.right - viewportPadding
+
+    setDropdownAlign(
+      spaceRight >= dropdownWidth || spaceRight >= spaceLeft ? 'left' : 'right'
+    )
+  }, [])
+
+  const toggleDropdown = () => {
+    setIsOpen((currentIsOpen) => {
+      const nextIsOpen = !currentIsOpen
+
+      if (nextIsOpen) {
+        requestAnimationFrame(updateDropdownAlignment)
+      }
+
+      return nextIsOpen
+    })
+  }
 
   const changeLanguage = (newLocale: 'pt' | 'en' | 'es') => {
     setLocale(newLocale)
@@ -30,6 +57,19 @@ export default function LanguageSelector() {
       document.removeEventListener('mousedown', handleClickOutside)
     }
   }, [])
+
+  useEffect(() => {
+    if (!isOpen) {
+      return
+    }
+
+    updateDropdownAlignment()
+    window.addEventListener('resize', updateDropdownAlignment)
+
+    return () => {
+      window.removeEventListener('resize', updateDropdownAlignment)
+    }
+  }, [isOpen, updateDropdownAlignment])
 
   const languages = [
     { value: 'pt', label: 'Português' },
@@ -57,7 +97,11 @@ export default function LanguageSelector() {
         />
       </button>
       {isOpen && (
-        <div className="absolute right-0 z-50 mt-3 w-52 rounded-[1.5rem] border border-border/70 bg-popover/95 p-2 text-popover-foreground shadow-[0_24px_60px_-32px_hsl(var(--foreground)/0.5)] backdrop-blur-xl">
+        <div
+          className={`absolute top-full z-50 mt-3 w-52 max-w-[calc(100vw-2rem)] rounded-[1.5rem] border border-border/70 bg-popover/95 p-2 text-popover-foreground shadow-[0_24px_60px_-32px_hsl(var(--foreground)/0.5)] backdrop-blur-xl ${
+            dropdownAlign === 'left' ? 'left-0' : 'right-0'
+          }`}
+        >
           {languages.map((language) => (
             <button
               key={language.value}

--- a/components/PlayerList.tsx
+++ b/components/PlayerList.tsx
@@ -40,26 +40,29 @@ export default function PlayerList({
   }
 
   return (
-    <div className="space-y-6">
+    <div className="min-w-0 space-y-6">
       <form
         onSubmit={handleAddPlayer}
-        className="rounded-[1.8rem] border border-border/70 bg-background/60 p-3 backdrop-blur sm:p-4"
+        className="min-w-0 rounded-[1.8rem] border border-border/70 bg-background/60 p-3 backdrop-blur sm:p-4"
       >
-        <div className="flex flex-col gap-3 md:flex-row md:items-center">
+        <div className="flex min-w-0 flex-col gap-3 md:flex-row md:items-center">
           <input
             type="text"
             value={newPlayerName}
             onChange={(e) => setNewPlayerName(e.target.value)}
             placeholder={t('playerOrTeam')}
-            className="input flex-grow"
+            className="input min-w-0 flex-grow"
           />
-          <button type="submit" className="btn btn-primary w-full md:w-auto">
+          <button
+            type="submit"
+            className="btn btn-primary w-full whitespace-normal md:w-auto"
+          >
             <Plus className="h-4 w-4" />
             {t('addPlayerOrTeam')}
           </button>
         </div>
       </form>
-      <ul className="grid gap-4">
+      <ul className="grid min-w-0 gap-4">
         {players.map((player, index) => (
           <PlayerItem
             key={index}
@@ -117,10 +120,10 @@ function PlayerItem({
     player.score % 1 === 0 ? player.score : player.score.toFixed(2)
 
   return (
-    <li className="rounded-[1.8rem] border border-border/70 bg-background/70 p-4 shadow-sm backdrop-blur sm:p-5">
-      <div className="flex flex-col gap-5 xl:flex-row xl:items-start xl:justify-between">
+    <li className="min-w-0 rounded-[1.8rem] border border-border/70 bg-background/70 p-4 shadow-sm backdrop-blur sm:p-5">
+      <div className="flex min-w-0 flex-col gap-5 xl:flex-row xl:items-start xl:justify-between">
         {isEditing ? (
-          <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-center">
+          <div className="flex w-full min-w-0 flex-col gap-3 sm:flex-row sm:items-center">
             <input
               type="text"
               value={editedName}
@@ -137,10 +140,10 @@ function PlayerItem({
             </button>
           </div>
         ) : (
-          <div className="space-y-3">
+          <div className="min-w-0 space-y-3">
             <span className="section-label">{t('player')}</span>
             <div className="flex flex-wrap items-center gap-3">
-              <span className="text-2xl font-semibold tracking-[-0.04em]">
+              <span className="min-w-0 break-words text-2xl font-semibold tracking-[-0.04em]">
                 {player.name}
               </span>
               <button
@@ -158,7 +161,7 @@ function PlayerItem({
           </div>
         )}
 
-        <div className="flex w-full max-w-sm flex-col gap-4">
+        <div className="flex w-full min-w-0 max-w-sm flex-col gap-4">
           <div className="rounded-[1.5rem] border border-border/70 bg-card/80 p-4">
             <div className="mb-3 flex items-center justify-between">
               <span className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
@@ -168,7 +171,7 @@ function PlayerItem({
                 +/-
               </span>
             </div>
-            <div className="flex items-center gap-3">
+            <div className="flex min-w-0 items-center gap-3">
               <button
                 type="button"
                 onClick={() => {
@@ -188,7 +191,7 @@ function PlayerItem({
                 type="number"
                 value={roundPoints}
                 onChange={(e) => setRoundPoints(e.target.value)}
-                className="input h-12 text-center font-mono text-lg"
+                className="input h-12 min-w-0 text-center font-mono text-lg"
                 placeholder="0"
                 step="any"
               />

--- a/components/ScoreBoard.tsx
+++ b/components/ScoreBoard.tsx
@@ -7,20 +7,20 @@ export default function ScoreBoard({ players }: { players: Player[] }) {
   const sortedPlayers = [...players].sort((a, b) => b.score - a.score)
 
   return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-between gap-3">
-        <div className="space-y-2">
+    <div className="min-w-0 space-y-4">
+      <div className="flex min-w-0 items-center justify-between gap-3">
+        <div className="min-w-0 space-y-2">
           <span className="section-label">{t('scoreboard')}</span>
-          <h2 className="text-2xl font-semibold tracking-[-0.05em]">
+          <h2 className="break-words text-2xl font-semibold tracking-[-0.05em]">
             {t('scoreboard')}
           </h2>
         </div>
-        <div className="flex h-11 w-11 items-center justify-center rounded-[1.2rem] bg-primary/10 text-primary">
+        <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-[1.2rem] bg-primary/10 text-primary">
           <Medal className="h-5 w-5" />
         </div>
       </div>
 
-      <div className="overflow-hidden rounded-[1.8rem] border border-border/70 bg-background/70">
+      <div className="min-w-0 overflow-x-auto rounded-[1.8rem] border border-border/70 bg-background/70">
         <table className="w-full border-separate border-spacing-0">
           <thead className="bg-muted/70 text-xs uppercase tracking-[0.2em] text-muted-foreground">
             <tr>
@@ -48,7 +48,7 @@ export default function ScoreBoard({ players }: { players: Player[] }) {
                     {index + 1}
                   </span>
                 </td>
-                <td className="border-t border-border/60 px-4 py-3 font-medium">
+                <td className="max-w-[10rem] break-words border-t border-border/60 px-4 py-3 font-medium">
                   {player.name}
                 </td>
                 <td className="border-t border-border/60 px-4 py-3 text-right font-mono font-semibold">

--- a/components/ThemeSwitcher.tsx
+++ b/components/ThemeSwitcher.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useLanguage } from './LanguageContext'
 import { Check, ChevronDown, Monitor, Moon, Sun } from 'lucide-react'
 
@@ -9,7 +9,24 @@ export default function ThemeSwitcher() {
   const [theme, setTheme] = useState<Theme>('system')
   const [isOpen, setIsOpen] = useState(false)
   const [isMounted, setIsMounted] = useState(false)
+  const [dropdownAlign, setDropdownAlign] = useState<'left' | 'right'>('right')
   const dropdownRef = useRef<HTMLDivElement>(null)
+
+  const updateDropdownAlignment = useCallback(() => {
+    if (!dropdownRef.current) {
+      return
+    }
+
+    const triggerRect = dropdownRef.current.getBoundingClientRect()
+    const dropdownWidth = 208
+    const viewportPadding = 16
+    const spaceRight = window.innerWidth - triggerRect.left - viewportPadding
+    const spaceLeft = triggerRect.right - viewportPadding
+
+    setDropdownAlign(
+      spaceRight >= dropdownWidth || spaceRight >= spaceLeft ? 'left' : 'right'
+    )
+  }, [])
 
   useEffect(() => {
     const savedTheme = (localStorage.getItem('theme') as Theme) ?? 'system'
@@ -33,6 +50,19 @@ export default function ThemeSwitcher() {
       document.removeEventListener('mousedown', handleClickOutside)
     }
   }, [])
+
+  useEffect(() => {
+    if (!isOpen) {
+      return
+    }
+
+    updateDropdownAlignment()
+    window.addEventListener('resize', updateDropdownAlignment)
+
+    return () => {
+      window.removeEventListener('resize', updateDropdownAlignment)
+    }
+  }, [isOpen, updateDropdownAlignment])
 
   const applyTheme = (newTheme: Theme) => {
     const root = document.documentElement
@@ -64,11 +94,23 @@ export default function ThemeSwitcher() {
 
   const ThemeIcon = themeIcons[theme]
 
+  const toggleDropdown = () => {
+    setIsOpen((currentIsOpen) => {
+      const nextIsOpen = !currentIsOpen
+
+      if (nextIsOpen) {
+        requestAnimationFrame(updateDropdownAlignment)
+      }
+
+      return nextIsOpen
+    })
+  }
+
   return (
     <div className="relative" ref={dropdownRef}>
       <button
         type="button"
-        onClick={() => setIsOpen(!isOpen)}
+        onClick={toggleDropdown}
         className="btn btn-secondary min-w-[9.5rem] justify-between px-4 py-3"
         aria-expanded={isOpen}
       >
@@ -83,7 +125,11 @@ export default function ThemeSwitcher() {
         />
       </button>
       {isMounted && isOpen && (
-        <div className="absolute right-0 z-50 mt-3 w-52 rounded-[1.5rem] border border-border/70 bg-popover/95 p-2 text-popover-foreground shadow-[0_24px_60px_-32px_hsl(var(--foreground)/0.5)] backdrop-blur-xl">
+        <div
+          className={`absolute top-full z-50 mt-3 w-52 max-w-[calc(100vw-2rem)] rounded-[1.5rem] border border-border/70 bg-popover/95 p-2 text-popover-foreground shadow-[0_24px_60px_-32px_hsl(var(--foreground)/0.5)] backdrop-blur-xl ${
+            dropdownAlign === 'left' ? 'left-0' : 'right-0'
+          }`}
+        >
           {(
             [
               ['system', Monitor],


### PR DESCRIPTION
Summary:
- keep theme and language dropdowns inside the mobile viewport
- hide setup summary metric cards until a game has started
- add a Finish Game action that saves the current game to history without requiring a winner

Validation:
- npm run lint:check
- npm run typecheck
- vitest suite (3 passed)
- npm run build
- mobile headless check for dropdown bounds and finish-game history save

Stacked on #50 to avoid mixing the UI refactor diff with this feature.